### PR TITLE
Fixed error by template generation at first time

### DIFF
--- a/gulp/tasks/development.js
+++ b/gulp/tasks/development.js
@@ -7,6 +7,6 @@ gulp.task('dev', ['clean'], function(cb) {
 
   global.isProd = false;
 
-  runSequence(['styles', 'images', 'fonts', 'views', 'browserify'], 'watch', cb);
+  runSequence(['styles', 'images', 'fonts', 'views'], 'browserify', 'watch', cb);
 
 });


### PR DESCRIPTION
When the view is too heavy and takes time to generate, it won't be available for browserify to import